### PR TITLE
Remove accents, change logical keywords to equivalent characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Debug/
+Release/

--- a/Bubble.cpp
+++ b/Bubble.cpp
@@ -62,13 +62,13 @@ void BubbleManager::interactWithShip(Ship& ship)
       {
         if (didDetectPassively(bubble))
         {
-		      ship.sense(SensorDataElement
-		      {
-			      SensorDataElement::Passive, //detectType
-			      bubble.emitter,         //player
-			      bubble.origin,          //place
-			      bubble.emitterVelocity, //velocity
-			      bubble.origin + bubble.emitterVelocity * ROUND_TIME * bubble.age, //nextPlace
+          ship.sense(SensorDataElement
+          {
+            SensorDataElement::Passive, //detectType
+            bubble.emitter,         //player
+            bubble.origin,          //place
+            bubble.emitterVelocity, //velocity
+            bubble.origin + bubble.emitterVelocity * ROUND_TIME * bubble.age, //nextPlace
             isSureFire(bubble) //sureFire?
           });
         }

--- a/Bubble.cpp
+++ b/Bubble.cpp
@@ -46,7 +46,7 @@ void BubbleManager::add(Bubble bubble)
 
 void BubbleManager::interactWithShip(Ship& ship)
 {
-  for (Bubble bubble : bubbles)
+  for (Bubble& bubble : bubbles)
   {
     //I dont want self-detections.
     if (bubble.emitter == ship.getOwner())

--- a/Bubble.cpp
+++ b/Bubble.cpp
@@ -62,13 +62,13 @@ void BubbleManager::interactWithShip(Ship& ship)
       {
         if (didDetectPassively(bubble))
         {
-          ship.sense(SensorDataElement
-          {
-            SensorDataElement::Passive, //detectType
-            bubble.emitter,         //player
-            bubble.origin,          //place
-            bubble.emitterVelocity, //velocity
-            Point(),//moveObject(bubble.origin, bubble.emitterVelocity, {0, 0, 0}, ROUND_TIME, 0).first, 
+		      ship.sense(SensorDataElement
+		      {
+			      SensorDataElement::Passive, //detectType
+			      bubble.emitter,         //player
+			      bubble.origin,          //place
+			      bubble.emitterVelocity, //velocity
+			      bubble.origin + bubble.emitterVelocity * ROUND_TIME * bubble.age, //nextPlace
             isSureFire(bubble) //sureFire?
           });
         }
@@ -85,7 +85,7 @@ void BubbleManager::interactWithShip(Ship& ship)
             bubble.emitter,
             bubble.origin,
             bubble.emitterVelocity,
-            Point(),//placeHolder
+            bubble.origin + bubble.emitterVelocity * ROUND_TIME * bubble.age, //nextPlace
             isSureFire(bubble)
           });
         }

--- a/Bubble.cpp
+++ b/Bubble.cpp
@@ -114,24 +114,25 @@ ostream& operator<<(ostream& os, const Bubble& b) // only for test
   switch (b.btype)
   {
     case Bubble::Active:
-    cout << "Aktív buborék!" << endl;
+    cout << "Aktiv buborek!" << endl;
     break;
 
     case Bubble::Passive:
-    cout << "Passzív buborék!" << endl;
+    cout << "Passziv buborek!" << endl;
     break;
 
     case Bubble::Reflection:
-    cout << "Visszaverődő buborék!" << endl;
+    cout << "Visszaverodo buborek!" << endl;
     break;
   }
   if (b.btype == Bubble::Reflection)
   {
-    cout << "Tudja fogadni: " << b.receiver << ". játékos." << endl;
+    cout << "Tudja fogadni: " << b.receiver << ". jatekos." << endl;
   }
-  cout << "Középpont: " << b.origin << endl;
-  cout << "Keltő játékos: " << b.emitter << endl;
-  cout << "Keltő játékos sebssége keltéskor: " << b.emitterVelocity << endl;
-  cout << "Láthatóság: " << b.visibility << endl;
-  cout << "Kora: " << b.age << " kör."; // no endl
+  cout << "Kozeppont: " << b.origin << endl;
+  cout << "Kelto jatekos: " << b.emitter << endl;
+  cout << "Kelto jatekos sebssege kelteskor: " << b.emitterVelocity << endl;
+  cout << "Lathatosag: " << b.visibility << endl;
+  cout << "Kora: " << b.age << " kor."; // no endl
+  return os;
 }

--- a/Bubble.h
+++ b/Bubble.h
@@ -3,6 +3,7 @@
 
 #include <iostream>
 #include <vector>
+#include <list>
 #include "Point.h"
 #include "Ship.h"
 #include "constants.h"
@@ -24,7 +25,7 @@ public:
 class BubbleManager
 {
 private:
-  std::vector<Bubble> bubbles;
+  std::list<Bubble> bubbles;
   bool didDetectPassively(Bubble bubble) const;
   bool didDetectActively(Bubble bubble) const;
   bool isSureFire(Bubble bubble) const;

--- a/Bubble.h
+++ b/Bubble.h
@@ -3,7 +3,6 @@
 
 #include <iostream>
 #include <vector>
-#include <list>
 #include "Point.h"
 #include "Ship.h"
 #include "constants.h"

--- a/Game.cpp
+++ b/Game.cpp
@@ -37,7 +37,7 @@ void Game::manageBubbles()
   //create bubbles
   for (const Ship& ship : ships)
   {
-    if (!ship.isDestroyed())
+    if (not ship.isDestroyed())
     {
       //passive bubble
       int vis = ship.getVisibility(); 
@@ -111,7 +111,7 @@ void Game::moveShips()
 {
   for (Ship& ship : ships)
   {
-    if (!ship.isDestroyed())
+    if (not ship.isDestroyed())
     {
       ship.move(ROUND_TIME);
       //reaching origo == win
@@ -179,7 +179,7 @@ void Game::mainGameLoop()
     }
     playRound();
     roundNumber++;
-  } while (!winManager.isOver());
+  } while (not winManager.isOver());
   giveWinScreen();
 }
 
@@ -195,6 +195,7 @@ numOfShips(numOfShips), winManager(numOfShips), projectiles(numOfShips, -1)
 
 int main()
 {
+  setlocale(LC_ALL,"");
   srand(time(NULL));
   string inp;
   do

--- a/Game.cpp
+++ b/Game.cpp
@@ -17,15 +17,15 @@ using namespace std;
 void Game::askToContinue(int nextPlayer) const
 {
   terminalClear();
-  cout << nextPlayer << ". játékos köre következik!" << endl;
-  cout << "Nyomj entert, ha kezdődhet." << endl;
+  cout << nextPlayer << ". jatekos kore kovetkezik!" << endl;
+  cout << "Nyomj entert, ha kezdodhet." << endl;
   waitForEnter();
 }
 
 void Game::giveInformation(int currentPlayer) const
 {
-  cout << "Kör eleji információk:" << endl;
-  cout << roundNumber << ". kör" << endl << endl;
+  cout << "Kor eleji informaciok:" << endl;
+  cout << roundNumber << ". kor" << endl << endl;
   cout << ships[currentPlayer] << endl << endl;
   ships[currentPlayer].giveSensorData();
   cout << "----------------------" << endl;
@@ -37,7 +37,7 @@ void Game::manageBubbles()
   //create bubbles
   for (const Ship& ship : ships)
   {
-    if (not ship.isDestroyed())
+    if (!ship.isDestroyed())
     {
       //passive bubble
       int vis = ship.getVisibility(); 
@@ -111,7 +111,7 @@ void Game::moveShips()
 {
   for (Ship& ship : ships)
   {
-    if (not ship.isDestroyed())
+    if (!ship.isDestroyed())
     {
       ship.move(ROUND_TIME);
       //reaching origo == win
@@ -137,7 +137,7 @@ void Game::manageDetections()
 void Game::playRound()
 {
   terminalClear();
-  cout << "Kör lejátszása." << endl;
+  cout << "Kor lejatszasa." << endl;
   
   manageBubbles();
   manageProjectiles();
@@ -152,10 +152,10 @@ void Game::giveWinScreen()
 {
   if (winManager.hasWinner())
   {
-    cout << "Az " << winManager.getWinner() << ". játékos nyert!" << endl;
+    cout << "Az " << winManager.getWinner() << ". jatekos nyert!" << endl;
   } else
   {
-    cout << "Mindenki elpusztult a csatában!" << endl;
+    cout << "Mindenki elpusztult a csataban!" << endl;
   }
 }
 
@@ -179,7 +179,7 @@ void Game::mainGameLoop()
     }
     playRound();
     roundNumber++;
-  } while (not winManager.isOver());
+  } while (!winManager.isOver());
   giveWinScreen();
 }
 
@@ -200,10 +200,10 @@ int main()
   do
   {
     unsigned int numOfShips;
-    cout << "Hajók száma: ";
+    cout << "Hajok szama: ";
     cin >> numOfShips;
     Game game(numOfShips);
-    cout << "Akarsz új játékot kezdeni? (y - igen, bármi más - nem)" << endl;
+    cout << "Akarsz uj jatekot kezdeni? (y - igen, barmi mas - nem)" << endl;
     cin >> inp;
   } while (inp == "y");
   return 0;

--- a/Ship.cpp
+++ b/Ship.cpp
@@ -12,11 +12,11 @@ int Ship::getSpentEnergy() const
 
 ostream& operator<<(ostream& os, const Command& c)
 {
-  cout << "Gyorsulás: " << c.accel << endl;
-  cout << "Tüzel-e: " << (c.didFire?"igen":"nem") << endl;
+  cout << "Gyorsulas: " << c.accel << endl;
+  cout << "Tuzel-e: " << (c.didFire?"igen":"nem") << endl;
   if (c.didFire)
   {
-    cout << "Cél: " << c.aim << endl;
+    cout << "Cel: " << c.aim << endl;
   }
   cout << "Sensor energia: " <<c. sensorEnergy; //no endl
   return os;
@@ -24,12 +24,12 @@ ostream& operator<<(ostream& os, const Command& c)
 
 ostream& operator<<(ostream& os, const SensorDataElement& sde)
 {
-  cout << ((sde.detectType == SensorDataElement::Active)?"Aktív":"Passzív") << " szenzor jelzett!" << endl;
-  cout << "Játékos: " << sde.player << endl;
+  cout << ((sde.detectType == SensorDataElement::Active)?"Aktiv":"Passziv") << " szenzor jelzett!" << endl;
+  cout << "Jatekos: " << sde.player << endl;
   cout << "Hely: " << sde.place << endl;
-  cout << "Sebesség: " << sde.velocity << endl;
-  cout << "Jósolt hely: " << sde.nextPlace << endl;
-  cout << "Biztos-e a találat: " << (sde.sureFire?"igen":"nem"); // no endl
+  cout << "Sebesseg: " << sde.velocity << endl;
+  cout << "Josolt hely: " << sde.nextPlace << endl;
+  cout << "Biztos-e a talalat: " << (sde.sureFire?"igen":"nem"); // no endl
   return os;
 }
 
@@ -72,7 +72,7 @@ void Ship::flushSensorData()
 
 void Ship::giveSensorData() const
 {
-  if (not destroyed)
+  if (!destroyed)
   {
     for (auto sde : sensorData)
     {
@@ -90,7 +90,7 @@ void Ship::getCommand()
   {
     string input;
     getline(cin, input);
-    if (input == "" or input == "\n")
+    if (input == "" || input == "\n")
     {
       continue;
     }
@@ -100,14 +100,14 @@ void Ship::getCommand()
     {
       if (cmd.size() != 4)
       {
-        cout << "Rossz számú szó!" << endl;
+        cout << "Rossz szamu szo!" << endl;
       } else
       {
         command.accel = {strTo<float>(cmd[1]), strTo<float>(cmd[2]), strTo<float>(cmd[3])};
         if (command.accel.length() > maxAcceleration)
         {
-          cout << "Túl nagy gyorsulást adtál meg!" << endl;
-          cout << "A hajód " << maxAcceleration << " gyorsulásra képes!" << endl;
+          cout << "Tul nagy gyorsulast adtal meg!" << endl;
+          cout << "A hajod " << maxAcceleration << " gyorsulasra kepes!" << endl;
           command.accel = {0, 0, 0};
         } 
       }
@@ -115,7 +115,7 @@ void Ship::getCommand()
     {
       if (cmd.size() != 2)
       {
-        cout << "Rossz számú szó!" << endl;
+        cout << "Rossz szamu szo!" << endl;
       } else
       {
         if (cmd[1] == "off")
@@ -139,7 +139,7 @@ void Ship::getCommand()
             command.aim = strTo<float>(cmd[1]);
           } else
           {
-            cout << "Nem biztos a lövés!" << endl;
+            cout << "Nem biztos a loves!" << endl;
           }
         }
       }
@@ -150,13 +150,13 @@ void Ship::getCommand()
         command.sensorEnergy = strTo<float>(cmd[1]);
         if (strTo<float>(cmd[1]) > maxSensorEnergy)
         {
-          cout << "Túl nagy szenzor energiát adtál meg!" << endl;
-          cout << "A hajód " << maxSensorEnergy << "-re képes!" << endl;
+          cout << "Tul nagy szenzor energiat adtal meg!" << endl;
+          cout << "A hajod " << maxSensorEnergy << "-re kepes!" << endl;
           command.sensorEnergy = 0;
         }
       } else
       {
-        cout << "Rossz számú szó!" << endl;
+        cout << "Rossz szamu szo!" << endl;
       }
     } else if (cmd[0] == "data")
     {
@@ -168,8 +168,8 @@ void Ship::getCommand()
         gettingInput = false;
       } else
       {
-        cout << getSpentEnergy() << " energiát szeretnél felhasználni." << endl;
-        cout << "A hajód generátora maximum " << maxGeneratorEnergy << "-re képes." << endl;
+        cout << getSpentEnergy() << " energiat szeretnel felhasznalni." << endl;
+        cout << "A hajod generatora maximum " << maxGeneratorEnergy << "-re kepes." << endl;
       }
     } else
     {
@@ -243,11 +243,11 @@ ostream& operator<<(ostream& os, const Ship& s)
 {
   if (s.destroyed)
   {
-    os << "A hajó megsemmisült!"; // no endl
+    os << "A hajo megsemmisult!"; // no endl
   } else
   {
     os << "Helyvektor: " << s.place << endl;
-    os << "Sebességvektor: " << s.velocity; // no endl
+    os << "Sebessegvektor: " << s.velocity; // no endl
   }
   return os;
 }

--- a/Ship.cpp
+++ b/Ship.cpp
@@ -39,16 +39,16 @@ void Object::move(Point accel, float time)
   int numOfSolut;
   float a = pow(accel.length(), 2);
   float b = 2*(velocity.x*accel.x + velocity.y*accel.y + velocity.z*accel.z);
-  float c = pow(velocity.length(), 2) - pow(maxVelocity, 2);
+  float c = pow(velocity.length(), 2) - pow(maxVelocity, 2); //solve (a+vt)^2 = vmax^2 for t
   if (a == 0)
   {
     velocity = velocity;
     place = place + velocity*time;
   } else
   {
-    solve2(a, b, c, solut, numOfSolut);
+    solve2(a, b, c, solut, numOfSolut); //calculate time of reacing maximum velocity
     float reachMaxT = max(solut[0], solut[1]);
-    if (reachMaxT < 0 || numOfSolut != 2)
+    if (reachMaxT < 0 || numOfSolut != 0) 
     {
       throw 1;
     }
@@ -72,7 +72,7 @@ void Ship::flushSensorData()
 
 void Ship::giveSensorData() const
 {
-  if (!destroyed)
+  if (not destroyed)
   {
     for (auto sde : sensorData)
     {
@@ -90,7 +90,7 @@ void Ship::getCommand()
   {
     string input;
     getline(cin, input);
-    if (input == "" || input == "\n")
+    if (input == "" or input == "\n")
     {
       continue;
     }

--- a/WinManager.cpp
+++ b/WinManager.cpp
@@ -45,7 +45,7 @@ void WinManager::win(unsigned int player)
   {
     throw NOT_EXISTING_PLAYER;
   }
-  if (!canWin[player])
+  if (not canWin[player])
   {
     throw ALREADY_LOST;
   }
@@ -61,7 +61,7 @@ bool WinManager::isOver() const
 
 bool WinManager::hasWinner() const
 {
-  if (!isGameOver)
+  if (not isGameOver)
   {
     throw GAME_NOT_OVER;
   }
@@ -70,11 +70,11 @@ bool WinManager::hasWinner() const
 
 unsigned int WinManager::getWinner() const
 {
-  if (!isGameOver)
+  if (not isGameOver)
   {
     throw GAME_NOT_OVER;
   }
-  if (!hasWin)
+  if (not hasWin)
   {
     throw NO_WINNER;
   }

--- a/WinManager.cpp
+++ b/WinManager.cpp
@@ -45,7 +45,7 @@ void WinManager::win(unsigned int player)
   {
     throw NOT_EXISTING_PLAYER;
   }
-  if (not canWin[player])
+  if (!canWin[player])
   {
     throw ALREADY_LOST;
   }
@@ -61,7 +61,7 @@ bool WinManager::isOver() const
 
 bool WinManager::hasWinner() const
 {
-  if (not isGameOver)
+  if (!isGameOver)
   {
     throw GAME_NOT_OVER;
   }
@@ -70,11 +70,11 @@ bool WinManager::hasWinner() const
 
 unsigned int WinManager::getWinner() const
 {
-  if (not isGameOver)
+  if (!isGameOver)
   {
     throw GAME_NOT_OVER;
   }
-  if (not hasWin)
+  if (!hasWin)
   {
     throw NO_WINNER;
   }

--- a/helperFunctions.h
+++ b/helperFunctions.h
@@ -1,10 +1,16 @@
 #ifndef __HELPERFUNCS_H__
 #define __HELPERFUNCS_H__
 
+#define and &&
+#define or ||
+#define not !
+
 #include <iostream>
 #include <vector>
 #include <sstream>
 #include <algorithm>
+#include <list>
+#include <locale>
 
 //Function for solving quadratic equations.
 void solve2(float a, float b, float c, float sol[2], int& numOfSol);

--- a/helperFunctions.h
+++ b/helperFunctions.h
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <vector>
 #include <sstream>
+#include <algorithm>
 
 //Function for solving quadratic equations.
 void solve2(float a, float b, float c, float sol[2], int& numOfSol);

--- a/robotization dilemma.vcxproj
+++ b/robotization dilemma.vcxproj
@@ -1,0 +1,168 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{DFC3EC97-FCA7-42F2-818A-036A335AEA7F}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>robotizationdilemma</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="Bubble.cpp" />
+    <ClCompile Include="Game.cpp" />
+    <ClCompile Include="helperFunctions.cpp" />
+    <ClCompile Include="Point.cpp" />
+    <ClCompile Include="Ship.cpp" />
+    <ClCompile Include="WinManager.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Bubble.h" />
+    <ClInclude Include="constants.h" />
+    <ClInclude Include="Game.h" />
+    <ClInclude Include="helperFunctions.h" />
+    <ClInclude Include="Point.h" />
+    <ClInclude Include="Ship.h" />
+    <ClInclude Include="WinManager.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/robotization dilemma.vcxproj.filters
+++ b/robotization dilemma.vcxproj.filters
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Bubble.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Game.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="helperFunctions.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Point.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Ship.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="WinManager.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Bubble.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="constants.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Game.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="helperFunctions.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Point.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Ship.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="WinManager.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Removed accents from text, fixing garbled characters on some devices.

Changed the `or` and `not` keyword to the equivalent and more widely used and accepted `||` and `!`.

Also added visual studio project file, for people who prefer to use that development environment.